### PR TITLE
Fix curve scaling in ping envelope

### DIFF
--- a/audio_blocks/utility.env.ping.gendsp
+++ b/audio_blocks/utility.env.ping.gendsp
@@ -1,247 +1,247 @@
 {
-    "patcher": {
-        "fileversion": 1,
-        "appversion": {
-            "major": 9,
-            "minor": 0,
-            "revision": 7,
-            "architecture": "x64",
-            "modernui": 1
-        },
-        "classnamespace": "dsp.gen",
-        "rect": [
-            134.0,
-            134.0,
-            1061.0,
-            595.0
-        ],
-        "gridsize": [
-            15.0,
-            15.0
-        ],
-        "boxes": [
-            {
-                "box": {
-                    "id": "obj-9",
-                    "maxclass": "newobj",
-                    "numinlets": 1,
-                    "numoutlets": 0,
-                    "patching_rect": [
-                        515.0,
-                        883.0,
-                        35.0,
-                        22.0
-                    ],
-                    "text": "out 5"
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-8",
-                    "maxclass": "newobj",
-                    "numinlets": 1,
-                    "numoutlets": 0,
-                    "patching_rect": [
-                        398.75,
-                        882.0,
-                        35.0,
-                        22.0
-                    ],
-                    "text": "out 4"
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-6",
-                    "maxclass": "newobj",
-                    "numinlets": 1,
-                    "numoutlets": 0,
-                    "patching_rect": [
-                        282.5,
-                        882.0,
-                        35.0,
-                        22.0
-                    ],
-                    "text": "out 3"
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-7",
-                    "maxclass": "newobj",
-                    "numinlets": 1,
-                    "numoutlets": 0,
-                    "patching_rect": [
-                        166.25,
-                        882.0,
-                        35.0,
-                        22.0
-                    ],
-                    "text": "out 2"
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-1",
-                    "maxclass": "newobj",
-                    "numinlets": 0,
-                    "numoutlets": 1,
-                    "outlettype": [
-                        ""
-                    ],
-                    "patching_rect": [
-                        13.0,
-                        6.0,
-                        28.0,
-                        22.0
-                    ],
-                    "text": "in 1"
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-2",
-                    "maxclass": "newobj",
-                    "numinlets": 0,
-                    "numoutlets": 1,
-                    "outlettype": [
-                        ""
-                    ],
-                    "patching_rect": [
-                        1016.0,
-                        6.0,
-                        28.0,
-                        22.0
-                    ],
-                    "text": "in 2"
-                }
-            },
-            {
-                "box": {
-                    "code": "Buffer prm(\"voice_parameter_buffer\");\nBuffer changed_flags(\"changed_flags\");\n\nHistory ti,mu,ar,cu,lo,ve,ac,i1,i2,o2,cu_t(0),cu_a(0),cu_f(0),ga;\n\nHistory ov(0);  //last non-zero velocity\nHistory oov(0); //just for detect change\nHistory otrig(0); //likewise\nHistory otr(0); //for holding triggers until attdone\nHistory env(0);\nHistory attdone(1);\nHistory decdone(1);\nHistory target(0);\nHistory attrate(0.00001);\nHistory decrate(0.00001);\nHistory upda(0);\n\nParam voice_offset(0);\nParam voice_is(0);\nParam tr(0);\nParam v(0);\nParam panic(0);\n\nif(upda<=0){\n        upda = vectorsize + 4;\n        if(peek(changed_flags,voice_is,0)>0){\n                changed_flags.poke(0,voice_is);\n                ti = peek(prm, voice_offset, 0, channels=1);\n                mu = peek(prm, 1+voice_offset, 0, channels=1);\n                ar = peek(prm, 2+voice_offset, 0, channels=1);\n                cu = peek(prm, 3+voice_offset, 0, channels=1);\n                lo = peek(prm, 4+voice_offset, 0, channels=1);\n                ve = peek(prm, 5+voice_offset, 0, channels=1)*2 - 1;\n                ac = peek(prm, 6+voice_offset, 0, channels=1)*2 - 1;\n                i1 = floor(5*peek(prm, 7+voice_offset, 0, channels=1));\n                i2 = floor(3*peek(prm, 8+voice_offset, 0, channels=1));\n                o2 = floor(4*peek(prm, 9+voice_offset, 0, channels=1));\n                ga = 2*peek(prm, 10+voice_offset, 0, channels=1)-1;\n                same = peek(prm, 11+voice_offset, 0, channels=1)>0.5;\n                cu_f=cu*4;\n                cu_t=floor(cu_f);\n                cu_f-=cu_t;\n                cu_t+=1;\n                cu_a = same ? cu_t : (5-cu_t);\n                t=1+abs(cu-0.45)*23;\n                total_time = (pow(1000,ti)-1+0.0000000001)*60.06006006006006;\n                total_time *= max(0.000001,mu);\n                at = total_time * ar;\n                de = total_time * (1-ar);\n                attrate=t/mstosamps(at);\n                decrate=-t/mstosamps(de);\n        }\n}\nupda -= 1;\n\nvi=0;\nlevscale = 0;\ntrig=0;\nif(delta(tr)) trig += tr*attdone;\nif((delta(lo>0)>0)&&(env==0)){\n        trig=1;\n}\natr = attrate; der = decrate;\n\nif(i1==0){\n        trig+=(in1>0.00000001);\n        levscale += trig;\n}else if(i1==1){\n        levscale += trig;\n        trig = 0;\n        otrig=0;\n        vi += in1;\n        cu_t = clip(cu_t,2,3);\n        cu_f = clip(cu_f,0.001,0.999);\n}else if(i1==2){\n        atr /= (1+in1);\n}else if(i1==3){\n        der /= (1+in1);\n}else if(i1==4){\n        atr /= (1+in1);\n        der /= (1+in1);\n}\nif(in2!=0){\n        if(i2==0){\n                atr /= (1+in2);\n        }else if(i2==1){\n                der /= (1+in2);\n        }else if(i2==2){\n                atr /= (1+in2);\n                der /= (1+in2);\n        }\n}\nif(panic) {\n        target=0;\n        decdone=0;\n        der=-0.001;\n        env*=0.999;\n}\n\nif(v>0){\n        levscale = v * ve + (1-clip(ve,0,2));\n        trig += levscale;\n}\nif(vi!=oov){ //follow behaviour\n        oov=vi;\n        ov=vi;\n        target=vi;\n        if(target<env){\n                attdone=1;\n                decdone=0;\n        }else if(target>env){\n                decdone=1;\n                attdone=0;\n        }\n}\n\nif((trig!=otrig)&&(attdone==1)){\n        if(trig!=0){\n                attdone=0;\n                decdone=1;\n                otrig=trig;\n                ov = levscale+ac*env;\n                ov /= 2;\n                ov = clip(ov,-2,2);\n                ov = ov - (ov*ov*ov/3);\n                ov *= 2;\n                target=ov;\n        }else{\n                trig = 0;\n                otrig = 0;\n        }\n}\nif(!attdone){\n        t=clip(target-env,-0.9999,0.9999);\n        if(t>0.00001){\n                dx = selector(cu_a,(1-t)*(1-t*cu_f),1+t*(cu_f-1),1+cu_f*(t-1),(t+0.01)*(1+cu_f*(t-0.99)));\n                dx*=atr;\n                dx=clip(dx,0.0000001,t);\n                env+=dx;\n        }else{\n                env=target;\n                attdone=1;\n                if(i1!=1){\n                        decdone=0;\n                        target = 0;\n                        trig=0;\n                }\n        }\n}\nif(!decdone){\n        t=clip(target-env,-0.9999,0.9999);\n        if(t<-0.001){\n                dx = selector(cu_t,((t+1)*(t+1)-1)*(1-cu_f)+cu_f*t,t-cu_f*(t+1),-1-cu_f*t,-1-t*(1+cu_f+cu_f*t));\n                dx*= -der;\n                dx=clip(dx,t,-0.0000000001);\n                env+=dx;\n        }else{\n                env=target;\n                decdone=1;\n                if(lo){\n                        ov = ov*lo;\n                        if(ov>0.001){\n                                attdone=0;\n                                target=ov*lo;\n                        }\n                }\n        }\n}\n\nout1 = ga*env;\n\nif(o2==0){\n        out2 = target;\n}else if(o2==1){\n        out2 = attdone;\n}else if(o2==2){\n        out2 = decdone;\n}else{\n        out2 = delta(env);\n}\n\nout3 = attdone;\nout4 = decdone;\nout5 = (env<0.0001) * (attdone) * (lo==0)* (in1==0)*(in2==0);",
-                    "fontface": 0,
-                    "fontname": "<Monospaced>",
-                    "fontsize": 12.0,
-                    "id": "obj-3",
-                    "maxclass": "codebox",
-                    "numinlets": 2,
-                    "numoutlets": 5,
-                    "outlettype": [
-                        "",
-                        "",
-                        "",
-                        "",
-                        ""
-                    ],
-                    "patching_rect": [
-                        50.0,
-                        6.0,
-                        964.0,
-                        594.0
-                    ]
-                }
-            },
-            {
-                "box": {
-                    "id": "obj-4",
-                    "maxclass": "newobj",
-                    "numinlets": 1,
-                    "numoutlets": 0,
-                    "patching_rect": [
-                        50.0,
-                        882.0,
-                        35.0,
-                        22.0
-                    ],
-                    "text": "out 1"
-                }
-            }
-        ],
-        "lines": [
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-3",
-                        0
-                    ],
-                    "source": [
-                        "obj-1",
-                        0
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-3",
-                        1
-                    ],
-                    "source": [
-                        "obj-2",
-                        0
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-4",
-                        0
-                    ],
-                    "source": [
-                        "obj-3",
-                        0
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-6",
-                        0
-                    ],
-                    "source": [
-                        "obj-3",
-                        2
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-7",
-                        0
-                    ],
-                    "source": [
-                        "obj-3",
-                        1
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-8",
-                        0
-                    ],
-                    "source": [
-                        "obj-3",
-                        3
-                    ]
-                }
-            },
-            {
-                "patchline": {
-                    "destination": [
-                        "obj-9",
-                        0
-                    ],
-                    "source": [
-                        "obj-3",
-                        4
-                    ]
-                }
-            }
-        ]
-    }
+  "patcher": {
+    "fileversion": 1,
+    "appversion": {
+      "major": 9,
+      "minor": 0,
+      "revision": 7,
+      "architecture": "x64",
+      "modernui": 1
+    },
+    "classnamespace": "dsp.gen",
+    "rect": [
+      134.0,
+      134.0,
+      1061.0,
+      595.0
+    ],
+    "gridsize": [
+      15.0,
+      15.0
+    ],
+    "boxes": [
+      {
+        "box": {
+          "id": "obj-9",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [
+            515.0,
+            883.0,
+            35.0,
+            22.0
+          ],
+          "text": "out 5"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-8",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [
+            398.75,
+            882.0,
+            35.0,
+            22.0
+          ],
+          "text": "out 4"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-6",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [
+            282.5,
+            882.0,
+            35.0,
+            22.0
+          ],
+          "text": "out 3"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-7",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [
+            166.25,
+            882.0,
+            35.0,
+            22.0
+          ],
+          "text": "out 2"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-1",
+          "maxclass": "newobj",
+          "numinlets": 0,
+          "numoutlets": 1,
+          "outlettype": [
+            ""
+          ],
+          "patching_rect": [
+            13.0,
+            6.0,
+            28.0,
+            22.0
+          ],
+          "text": "in 1"
+        }
+      },
+      {
+        "box": {
+          "id": "obj-2",
+          "maxclass": "newobj",
+          "numinlets": 0,
+          "numoutlets": 1,
+          "outlettype": [
+            ""
+          ],
+          "patching_rect": [
+            1016.0,
+            6.0,
+            28.0,
+            22.0
+          ],
+          "text": "in 2"
+        }
+      },
+      {
+        "box": {
+          "code": "Buffer prm(\"voice_parameter_buffer\");\nBuffer changed_flags(\"changed_flags\");\n\nHistory ti,mu,ar,cu,lo,ve,ac,i1,i2,o2,cu_t(0),cu_a(0),cu_f(0),ga,cf(1);\n\nHistory ov(0);  //last non-zero velocity\nHistory oov(0); //just for detect change\nHistory otrig(0); //likewise\nHistory otr(0); //for holding triggers until attdone\nHistory env(0);\nHistory attdone(1);\nHistory decdone(1);\nHistory target(0);\nHistory attrate(0.00001);\nHistory decrate(0.00001);\nHistory upda(0);\n\nParam voice_offset(0);\nParam voice_is(0);\nParam tr(0);\nParam v(0);\nParam panic(0);\n\nif(upda<=0){\n        upda = vectorsize + 4;\n        if(peek(changed_flags,voice_is,0)>0){\n                changed_flags.poke(0,voice_is);\n                ti = peek(prm, voice_offset, 0, channels=1);\n                mu = peek(prm, 1+voice_offset, 0, channels=1);\n                ar = peek(prm, 2+voice_offset, 0, channels=1);\n                cu = peek(prm, 3+voice_offset, 0, channels=1);\n                lo = peek(prm, 4+voice_offset, 0, channels=1);\n                ve = peek(prm, 5+voice_offset, 0, channels=1)*2 - 1;\n                ac = peek(prm, 6+voice_offset, 0, channels=1)*2 - 1;\n                i1 = floor(5*peek(prm, 7+voice_offset, 0, channels=1));\n                i2 = floor(3*peek(prm, 8+voice_offset, 0, channels=1));\n                o2 = floor(4*peek(prm, 9+voice_offset, 0, channels=1));\n                ga = 2*peek(prm, 10+voice_offset, 0, channels=1)-1;\n                same = peek(prm, 11+voice_offset, 0, channels=1)>0.5;\n                cu_f=cu*4;\n                cu_t=floor(cu_f);\n                cu_f-=cu_t;\n                cu_t+=1;\n                cu_a = same ? cu_t : (5-cu_t);\n                cf = 1+abs(cu-0.45)*23;\n                total_time = (pow(1000,ti)-1+0.0000000001)*60.06006006006006;\n                total_time *= max(0.000001,mu);\n                at = total_time * ar;\n                de = total_time * (1-ar);\n                attrate=1/mstosamps(at);\n                decrate=-1/mstosamps(de);\n        }\n}\nupda -= 1;\n\nvi=0;\nlevscale = 0;\ntrig=0;\nif(delta(tr)) trig += tr*attdone;\nif((delta(lo>0)>0)&&(env==0)){\n        trig=1;\n}\natr = attrate; der = decrate;\n\nif(i1==0){\n        trig+=(in1>0.00000001);\n        levscale += trig;\n}else if(i1==1){\n        levscale += trig;\n        trig = 0;\n        otrig=0;\n        vi += in1;\n        cu_t = clip(cu_t,2,3);\n        cu_f = clip(cu_f,0.001,0.999);\n}else if(i1==2){\n        atr /= (1+in1);\n}else if(i1==3){\n        der /= (1+in1);\n}else if(i1==4){\n        atr /= (1+in1);\n        der /= (1+in1);\n}\nif(in2!=0){\n        if(i2==0){\n                atr /= (1+in2);\n        }else if(i2==1){\n                der /= (1+in2);\n        }else if(i2==2){\n                atr /= (1+in2);\n                der /= (1+in2);\n        }\n}\nif(panic) {\n        target=0;\n        decdone=0;\n        der=-0.001;\n        env*=0.999;\n}\n\nif(v>0){\n        levscale = v * ve + (1-clip(ve,0,2));\n        trig += levscale;\n}\nif(vi!=oov){ //follow behaviour\n        oov=vi;\n        ov=vi;\n        target=vi;\n        if(target<env){\n                attdone=1;\n                decdone=0;\n        }else if(target>env){\n                decdone=1;\n                attdone=0;\n        }\n}\n\nif((trig!=otrig)&&(attdone==1)){\n        if(trig!=0){\n                attdone=0;\n                decdone=1;\n                otrig=trig;\n                ov = levscale+ac*env;\n                ov /= 2;\n                ov = clip(ov,-2,2);\n                ov = ov - (ov*ov*ov/3);\n                ov *= 2;\n                target=ov;\n        }else{\n                trig = 0;\n                otrig = 0;\n        }\n}\nif(!attdone){\n        t=clip(target-env,-0.9999,0.9999);\n        if(t>0.00001){\n                dx = selector(cu_a,(1-t)*(1-t*cu_f),1+t*(cu_f-1),1+cu_f*(t-1),(t+0.01)*(1+cu_f*(t-0.99)));\n                dx*=atr*cf;\n                dx=clip(dx,0.0000001,t);\n                env+=dx;\n        }else{\n                env=target;\n                attdone=1;\n                if(i1!=1){\n                        decdone=0;\n                        target = 0;\n                        trig=0;\n                }\n        }\n}\nif(!decdone){\n        t=clip(target-env,-0.9999,0.9999);\n        if(t<-0.001){\n                dx = selector(cu_t,((t+1)*(t+1)-1)*(1-cu_f)+cu_f*t,t-cu_f*(t+1),-1-cu_f*t,-1-t*(1+cu_f+cu_f*t));\n                dx*=-der*cf;\n                dx=clip(dx,t,-0.0000000001);\n                env+=dx;\n        }else{\n                env=target;\n                decdone=1;\n                if(lo){\n                        ov = ov*lo;\n                        if(ov>0.001){\n                                attdone=0;\n                                target=ov*lo;\n                        }\n                }\n        }\n}\n\nout1 = ga*env;\n\nif(o2==0){\n        out2 = target;\n}else if(o2==1){\n        out2 = attdone;\n}else if(o2==2){\n        out2 = decdone;\n}else{\n        out2 = delta(env);\n}\n\nout3 = attdone;\nout4 = decdone;\nout5 = (env<0.0001) * (attdone) * (lo==0)* (in1==0)*(in2==0);\n",
+          "fontface": 0,
+          "fontname": "<Monospaced>",
+          "fontsize": 12.0,
+          "id": "obj-3",
+          "maxclass": "codebox",
+          "numinlets": 2,
+          "numoutlets": 5,
+          "outlettype": [
+            "",
+            "",
+            "",
+            "",
+            ""
+          ],
+          "patching_rect": [
+            50.0,
+            6.0,
+            964.0,
+            594.0
+          ]
+        }
+      },
+      {
+        "box": {
+          "id": "obj-4",
+          "maxclass": "newobj",
+          "numinlets": 1,
+          "numoutlets": 0,
+          "patching_rect": [
+            50.0,
+            882.0,
+            35.0,
+            22.0
+          ],
+          "text": "out 1"
+        }
+      }
+    ],
+    "lines": [
+      {
+        "patchline": {
+          "destination": [
+            "obj-3",
+            0
+          ],
+          "source": [
+            "obj-1",
+            0
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-3",
+            1
+          ],
+          "source": [
+            "obj-2",
+            0
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-4",
+            0
+          ],
+          "source": [
+            "obj-3",
+            0
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-6",
+            0
+          ],
+          "source": [
+            "obj-3",
+            2
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-7",
+            0
+          ],
+          "source": [
+            "obj-3",
+            1
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-8",
+            0
+          ],
+          "source": [
+            "obj-3",
+            3
+          ]
+        }
+      },
+      {
+        "patchline": {
+          "destination": [
+            "obj-9",
+            0
+          ],
+          "source": [
+            "obj-3",
+            4
+          ]
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Separate curve factor from duration in `utility.env.ping.gendsp`
- Compute attack/release rates solely from duration using `mstosamps`
- Apply curve factor only in envelope interpolation

## Testing
- `jq . audio_blocks/utility.env.ping.gendsp >/dev/null`
- `python - <<'PY'
import math
samplerate = 48000

def mstosamps(ms):
    return ms*samplerate/1000.0

at=100
de=200
for cu in [0.0,0.5,1.0]:
    cf = 1+abs(cu-0.45)*23
    attrate = 1/mstosamps(at)
    decrate = -1/mstosamps(de)
    print(f"cu={cu:.2f} -> attrate={attrate:.6f}, decrate={decrate:.6f}")
PY


------
https://chatgpt.com/codex/tasks/task_e_68c7d6c6bfc8832891e051c5d7d5381f