### PR TITLE
Add tempo-synced ping LFO block

### DIFF
--- a/audio_blocks/utility.lfo.ping.gendsp
+++ b/audio_blocks/utility.lfo.ping.gendsp
@@ -1,0 +1,277 @@
+{
+    "patcher": {
+        "fileversion": 1,
+        "appversion": {
+            "major": 9,
+            "minor": 0,
+            "revision": 7,
+            "architecture": "x64",
+            "modernui": 1
+        },
+        "classnamespace": "dsp.gen",
+        "rect": [
+            134.0,
+            134.0,
+            1061.0,
+            595.0
+        ],
+        "gridsize": [
+            15.0,
+            15.0
+        ],
+        "boxes": [
+            {
+                "box": {
+                    "id": "obj-9",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        515.0,
+                        883.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 5"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-8",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        398.75,
+                        882.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 4"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-6",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        282.5,
+                        882.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 3"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-7",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        166.25,
+                        882.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 2"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-1",
+                    "maxclass": "newobj",
+                    "numinlets": 0,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        13.0,
+                        6.0,
+                        28.0,
+                        22.0
+                    ],
+                    "text": "in 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-2",
+                    "maxclass": "newobj",
+                    "numinlets": 0,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        1016.0,
+                        6.0,
+                        28.0,
+                        22.0
+                    ],
+                    "text": "in 2"
+                }
+            },
+            {
+                "box": {
+                    "code": "Buffer prm(\"voice_parameter_buffer\");\nBuffer changed_flags(\"changed_flags\");\n\nHistory ti,mu,ar,cu,i1,i2,o2,ga,mirror(1),reuse(1);\nHistory cu_t(0),cu_a(0),cu_f(0);\nHistory cycle_samples(1),attack_samples(1),attack_ratio(0.5);\nHistory env(0);\nHistory prev_env(0);\nHistory stage(0);\nHistory trig_latched(0);\nHistory upda(0);\nHistory idle_state(1);\nHistory phase_counter(0);\nHistory attflag(0);\nHistory relflag(0);\n\nParam voice_offset(0);\nParam voice_is(0);\nParam tr(0);\nParam panic(0);\n\nif(upda<=0){\n        upda = vectorsize + 4;\n        if(peek(changed_flags,voice_is,0)>0){\n                changed_flags.poke(0,voice_is);\n                ti = peek(prm, voice_offset, 0, channels=1);\n                mu = peek(prm, 1+voice_offset, 0, channels=1);\n                ar = clip(peek(prm, 2+voice_offset, 0, channels=1),0.001,0.999);\n                cu = peek(prm, 3+voice_offset, 0, channels=1);\n                i1 = floor(4*peek(prm, 4+voice_offset, 0, channels=1));\n                i2 = floor(4*peek(prm, 5+voice_offset, 0, channels=1));\n                o2 = floor(4*peek(prm, 6+voice_offset, 0, channels=1));\n                ga = 2*peek(prm, 7+voice_offset, 0, channels=1)-1;\n                mirror = peek(prm, 8+voice_offset, 0, channels=1)>0.5;\n                reuse = peek(prm, 9+voice_offset, 0, channels=1)>0.5;\n                if(reuse){\n                        cu_f = cu*4;\n                        cu_t = clip(floor(cu_f)+1,1,4);\n                        cu_f = cu_f - floor(cu_f);\n                }else{\n                        cu_t = 2;\n                        cu_f = 0;\n                }\n                cu_a = mirror ? cu_t : (5-cu_t);\n                cu_a = clip(cu_a,1,4);\n        }\n}\nupda -= 1;\n\nmu_scale = max(0, mu);\nparam_time = (pow(1000,ti)-1+0.0000000001)*60.06006006006006;\nparam_time *= mu_scale;\ntap_time = max(0, in3);\nactive = max(tap_time > 0.000001, param_time > 0.000001);\nif(tap_time > 0.000001){\n        tap_selector = floor(clip(ti, 0, 1) * 18 + 0.5);\n        tap_selector = clip(tap_selector, 0, 18);\n        tap_ratio = selector(tap_selector+1, 0.0625,0.08333333333333333,0.125,0.16666666666666666,0.25,0.3333333333333333,0.5,0.6666666666666666,1,1.3333333333333333,2,4,8,12,16,20,24,28,32);\n        param_time = tap_time * tap_ratio * max(0.000001, mu_scale);\n        active = param_time > 0.000001;\n}\nif(active){\n        attack_ms = max(0.001, param_time * ar);\n        release_ms = max(0.001, param_time * (1-ar));\n        attack_samples = mstosamps(attack_ms);\n        release_samples = mstosamps(release_ms);\n        cycle_samples = max(attack_samples + release_samples, 2);\n        attack_ratio = attack_samples / cycle_samples;\n}else{\n        attack_samples = 1;\n        release_samples = 1;\n        cycle_samples = 2;\n        attack_ratio = 0.5;\n}\nidle_state = active ? 0 : 1;\n\nif(panic){\n        env = 0;\n        prev_env = 0;\n        stage = 0;\n        phase_counter = 0;\n        trig_latched = 0;\n        attflag = 0;\n        relflag = 0;\n        idle_state = 1;\n        active = 0;\n}\n\nrate_mod = 1;\nphase_mod = 0;\ndepth_mod = 0;\nif(i1==1){\n        rate_mod += in1;\n}else if(i1==2){\n        phase_mod += in1;\n}else if(i1==3){\n        depth_mod += in1;\n}\nif(i2==1){\n        rate_mod += in2;\n}else if(i2==2){\n        phase_mod += in2;\n}else if(i2==3){\n        depth_mod += in2;\n}\nrate_mod = max(0.0001, rate_mod);\nphase_mod = phase_mod * 0.25;\ndepth_mod = clip(depth_mod, -1, 1);\n\nif(active){\n        phase_counter += rate_mod;\n        trig_event = (delta(tr)>0);\n        if(trig_event && (trig_latched==0)){\n                phase_counter = 0;\n                stage = 0;\n                trig_latched = 1;\n        }\n        if(phase_counter >= cycle_samples){\n                phase_counter -= cycle_samples;\n                stage = 0;\n                trig_latched = 0;\n                relflag = 1;\n        }else{\n                relflag = 0;\n        }\n        if(phase_counter >= attack_samples){\n                if(stage==0){\n                        stage = 1;\n                        attflag = 1;\n                }else{\n                        attflag = 0;\n                }\n        }else{\n                attflag = 0;\n                stage = 0;\n        }\n}else{\n        phase_counter = 0;\n        stage = 0;\n        trig_latched = 0;\n        attflag = 0;\n        relflag = 0;\n}\n\nphase_norm = active ? phase_counter / cycle_samples : 0;\nphase_mix = phase_norm + phase_mod;\nphase_out = phase_mix - floor(phase_mix);\nattack_ratio = clip(attack_ratio, 0.001, 0.999);\n\npi_const = acos(-1);\nprogress_a = (attack_ratio>0) ? clip(phase_out / attack_ratio,0,1) : 0;\nprogress_r = (attack_ratio<1) ? clip((phase_out - attack_ratio) / max(0.000001, 1-attack_ratio),0,1) : 0;\none_minus_a = max(0,1-progress_a);\nbase1 = 1 - pow(one_minus_a,4);\nbase2 = progress_a;\nbase3 = pow(progress_a,4);\nbase4 = 0.5 - 0.5*cos(progress_a*pi_const);\nbase1n = 1 - pow(max(0,1-progress_r),4);\nbase2n = progress_r;\nbase3n = pow(progress_r,4);\nbase4n = 0.5 - 0.5*cos(progress_r*pi_const);\n\ncurve_attack_idx = clip(cu_a,1,4);\ncurve_attack_next = clip(curve_attack_idx+1,1,4);\ncurve_release_idx = clip(cu_t,1,4);\ncurve_release_next = clip(curve_release_idx+1,1,4);\n\ncur_attack = selector(curve_attack_idx, base1, base2, base3, base4);\ncur_attack_next = selector(curve_attack_next, base1, base2, base3, base4);\ncur_release = selector(curve_release_idx, base1n, base2n, base3n, base4n);\ncur_release_next = selector(curve_release_next, base1n, base2n, base3n, base4n);\nattack_curve = cur_attack + (cur_attack_next - cur_attack) * cu_f;\nrelease_curve = cur_release + (cur_release_next - cur_release) * cu_f;\n\nif(active){\n        wave = (phase_out < attack_ratio) ? (-1 + 2*attack_curve) : (1 - 2*release_curve);\n        amp = ga * (1 + depth_mod);\n        env = wave * amp;\n}else{\n        env = 0;\n}\nderiv = env - prev_env;\nprev_env = env;\n\nphase_flag = (stage==1) * active;\n\nout1 = env;\nif(o2==0){\n        out2 = active ? ((phase_out < attack_ratio) ? 1 : -1) : 0;\n}else if(o2==1){\n        out2 = phase_flag;\n}else if(o2==2){\n        out2 = deriv;\n}else{\n        out2 = active ? (phase_out < attack_ratio) : 0;\n}\nout3 = attflag;\nout4 = relflag;\nout5 = idle_state;\n",
+                    "fontface": 0,
+                    "fontname": "<Monospaced>",
+                    "fontsize": 12.0,
+                    "id": "obj-3",
+                    "maxclass": "codebox",
+                    "numinlets": 3,
+                    "numoutlets": 5,
+                    "outlettype": [
+                        "",
+                        "",
+                        "",
+                        "",
+                        ""
+                    ],
+                    "patching_rect": [
+                        50.0,
+                        6.0,
+                        964.0,
+                        594.0
+                    ]
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-4",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        50.0,
+                        882.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-10",
+                    "maxclass": "newobj",
+                    "numinlets": 0,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        515.0,
+                        6.0,
+                        28.0,
+                        22.0
+                    ],
+                    "text": "in 3"
+                }
+            }
+        ],
+        "lines": [
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-3",
+                        0
+                    ],
+                    "source": [
+                        "obj-1",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-3",
+                        1
+                    ],
+                    "source": [
+                        "obj-2",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-4",
+                        0
+                    ],
+                    "source": [
+                        "obj-3",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-6",
+                        0
+                    ],
+                    "source": [
+                        "obj-3",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-7",
+                        0
+                    ],
+                    "source": [
+                        "obj-3",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-8",
+                        0
+                    ],
+                    "source": [
+                        "obj-3",
+                        3
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-9",
+                        0
+                    ],
+                    "source": [
+                        "obj-3",
+                        4
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-10",
+                        0
+                    ],
+                    "destination": [
+                        "obj-3",
+                        2
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/audio_blocks/utility.lfo.ping.json
+++ b/audio_blocks/utility.lfo.ping.json
@@ -1,0 +1,215 @@
+{
+    "utility.lfo.ping": {
+        "patcher": "utility.lfo.ping",
+        "type": "audio",
+        "block_ui_patcher": "blank.ui",
+        "help_text": "Tempo-synchronised ping LFO with tap/trigger inputs, envelope-family curves, configurable modulation inputs, and multi-mode auxiliary output.",
+        "max_polyphony": 0,
+        "upsample": 1,
+        "connections": {
+            "in": {
+                "audio": [
+                    "mod a",
+                    "mod b"
+                ],
+                "midi": [
+                    "trigger",
+                    "tap"
+                ]
+            },
+            "out": {
+                "audio": [
+                    "lfo out",
+                    "aux out"
+                ],
+                "midi": [
+                    "EOA",
+                    "EOR",
+                    "idle"
+                ],
+                "midi_watched": [
+                    0,
+                    1,
+                    1
+                ]
+            }
+        },
+        "panel": {
+            "parameters": [
+                0,
+                1,
+                2
+            ]
+        },
+        "groups": [
+            {
+                "contains": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "colour": 5
+            },
+            {
+                "contains": [
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "height": 0,
+                "colour": -10
+            },
+            {
+                "contains": [
+                    8,
+                    9
+                ],
+                "height": 3,
+                "colour": -20
+            }
+        ],
+        "parameters": [
+            {
+                "name": "time",
+                "type": "menu_l",
+                "values": [
+                    "64n",
+                    "32nt",
+                    "32n",
+                    "16nt",
+                    "16n",
+                    "8nt",
+                    "8n",
+                    "4nt",
+                    "4n",
+                    "2nt",
+                    "2n",
+                    "1n",
+                    "2b",
+                    "3b",
+                    "4b",
+                    "5b",
+                    "6b",
+                    "7b",
+                    "8b"
+                ],
+                "error_scale": 0.5,
+                "wrap": 0,
+                "default": 0.46,
+                "columns": 4
+            },
+            {
+                "name": "mult",
+                "type": "float",
+                "values": [
+                    "uni",
+                    0,
+                    2,
+                    "lin"
+                ],
+                "wrap": 0,
+                "default": 0.5
+            },
+            {
+                "name": "attack_release",
+                "type": "float",
+                "values": [
+                    "uni",
+                    0.001,
+                    0.999,
+                    "lin"
+                ],
+                "wrap": 0,
+                "default": 0.5
+            },
+            {
+                "name": "curve",
+                "type": "menu_f",
+                "values": [
+                    "exp",
+                    "lin",
+                    "log"
+                ],
+                "wrap": 0,
+                "default": 0.2
+            },
+            {
+                "name": "in1_mode",
+                "type": "menu_l",
+                "values": [
+                    "none",
+                    "rate",
+                    "phase",
+                    "depth"
+                ],
+                "force_label": 1,
+                "wrap": 1,
+                "default": 0
+            },
+            {
+                "name": "in2_mode",
+                "type": "menu_l",
+                "values": [
+                    "none",
+                    "rate",
+                    "phase",
+                    "depth"
+                ],
+                "force_label": 1,
+                "wrap": 1,
+                "default": 0
+            },
+            {
+                "name": "out2",
+                "type": "menu_l",
+                "values": [
+                    "target",
+                    "phase",
+                    "derivative",
+                    "gate"
+                ],
+                "force_label": 1,
+                "wrap": 1,
+                "default": 0
+            },
+            {
+                "name": "gain",
+                "type": "float",
+                "values": [
+                    "bi",
+                    -1,
+                    1,
+                    "lin"
+                ],
+                "wrap": 0,
+                "default": 1
+            },
+            {
+                "name": "attack_shape",
+                "type": "menu_b",
+                "nopervoice": 1,
+                "forcelabel": 1,
+                "values": [
+                    "attack_shape_shared",
+                    "attack_shape_mirror"
+                ],
+                "wrap": 1,
+                "default": 0.3
+            },
+            {
+                "name": "curve_family",
+                "type": "menu_b",
+                "nopervoice": 1,
+                "forcelabel": 1,
+                "values": [
+                    "curve_family_basic",
+                    "curve_family_pingenv"
+                ],
+                "wrap": 1,
+                "default": 0.7
+            }
+        ]
+    }
+}

--- a/audio_blocks/utility.lfo.ping.maxpat
+++ b/audio_blocks/utility.lfo.ping.maxpat
@@ -1,0 +1,3516 @@
+{
+    "patcher": {
+        "fileversion": 1,
+        "appversion": {
+            "major": 9,
+            "minor": 0,
+            "revision": 7,
+            "architecture": "x64",
+            "modernui": 1
+        },
+        "classnamespace": "box",
+        "rect": [
+            66.0,
+            112.0,
+            868.0,
+            556.0
+        ],
+        "gridsize": [
+            15.0,
+            15.0
+        ],
+        "boxes": [
+            {
+                "box": {
+                    "id": "obj-11",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        267.0,
+                        150.0,
+                        99.0,
+                        22.0
+                    ],
+                    "text": "prepend voice_is"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-67",
+                    "maxclass": "button",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "bang"
+                    ],
+                    "parameter_enable": 0,
+                    "patching_rect": [
+                        48.0,
+                        233.0,
+                        24.0,
+                        24.0
+                    ]
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-65",
+                    "maxclass": "newobj",
+                    "numinlets": 3,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        319.0,
+                        399.0,
+                        53.0,
+                        22.0
+                    ],
+                    "text": "clip 0. 1."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-64",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        319.0,
+                        368.0,
+                        41.0,
+                        22.0
+                    ],
+                    "text": "abs 0."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-63",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        267.0,
+                        499.0,
+                        39.0,
+                        22.0
+                    ],
+                    "text": "f -127"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-60",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        319.0,
+                        467.0,
+                        44.0,
+                        22.0
+                    ],
+                    "text": "* -127."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-59",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        204.0,
+                        465.0,
+                        39.0,
+                        22.0
+                    ],
+                    "text": "f -127"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-58",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        271.0,
+                        399.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "edge~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-43",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        319.0,
+                        337.0,
+                        64.0,
+                        22.0
+                    ],
+                    "text": "snapshot~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-57",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        "stop"
+                    ],
+                    "patching_rect": [
+                        537.0,
+                        308.0,
+                        48.0,
+                        22.0
+                    ],
+                    "text": "t b stop"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-56",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "stop",
+                        ""
+                    ],
+                    "patching_rect": [
+                        134.0,
+                        267.0,
+                        44.0,
+                        22.0
+                    ],
+                    "text": "t stop l"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-55",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        104.0,
+                        299.0,
+                        55.0,
+                        22.0
+                    ],
+                    "text": "del 3430"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-50",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "int",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        83.0,
+                        267.0,
+                        29.5,
+                        22.0
+                    ],
+                    "text": "t i b"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-38",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        48.0,
+                        267.0,
+                        29.5,
+                        22.0
+                    ],
+                    "text": "i"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-37",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        48.0,
+                        299.0,
+                        54.0,
+                        22.0
+                    ],
+                    "text": "pack 0 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-33",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "list"
+                    ],
+                    "patching_rect": [
+                        48.0,
+                        331.0,
+                        61.0,
+                        22.0
+                    ],
+                    "text": "funnel 2 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-28",
+                    "linecount": 2,
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        48.0,
+                        363.0,
+                        261.0,
+                        36.0
+                    ],
+                    "text": ";\r\nto_blockmanager is_output_used $1 $2 $3 midi"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-14",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        247.0,
+                        106.0,
+                        120.0,
+                        22.0
+                    ],
+                    "text": "prepend voice_offset"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-23",
+                    "maxclass": "newobj",
+                    "numinlets": 3,
+                    "numoutlets": 3,
+                    "outlettype": [
+                        "",
+                        "",
+                        ""
+                    ],
+                    "patching_rect": [
+                        204.0,
+                        399.0,
+                        56.0,
+                        22.0
+                    ],
+                    "text": "route 1 2"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-8",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "",
+                        ""
+                    ],
+                    "patching_rect": [
+                        298.0,
+                        79.0,
+                        115.0,
+                        22.0
+                    ],
+                    "text": "route enable_output"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-93",
+                    "maxclass": "newobj",
+                    "numinlets": 4,
+                    "numoutlets": 10,
+                    "outlettype": [
+                        "",
+                        "bang",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "int",
+                        "",
+                        ""
+                    ],
+                    "patching_rect": [
+                        183.0,
+                        46.0,
+                        134.0,
+                        22.0
+                    ],
+                    "text": "voiceheader_noparams"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-62",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "signal"
+                    ],
+                    "patching_rect": [
+                        267.0,
+                        431.0,
+                        59.0,
+                        22.0
+                    ],
+                    "text": "gate~ 1 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-61",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        204.0,
+                        431.0,
+                        52.0,
+                        22.0
+                    ],
+                    "text": "gate 1 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-42",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        722.0,
+                        312.0,
+                        29.5,
+                        22.0
+                    ],
+                    "text": "!- 0."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-41",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "",
+                        ""
+                    ],
+                    "patching_rect": [
+                        689.0,
+                        280.0,
+                        52.0,
+                        22.0
+                    ],
+                    "text": "gate 2 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-45",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        298.0,
+                        8.0,
+                        40.0,
+                        22.0
+                    ],
+                    "text": "active"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-54",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 3,
+                    "outlettype": [
+                        "bang",
+                        "",
+                        "int"
+                    ],
+                    "patcher": {
+                        "fileversion": 1,
+                        "appversion": {
+                            "major": 9,
+                            "minor": 0,
+                            "revision": 7,
+                            "architecture": "x64",
+                            "modernui": 1
+                        },
+                        "classnamespace": "box",
+                        "rect": [
+                            59.0,
+                            107.0,
+                            640.0,
+                            480.0
+                        ],
+                        "gridsize": [
+                            15.0,
+                            15.0
+                        ],
+                        "boxes": [
+                            {
+                                "box": {
+                                    "id": "obj-13",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        99.0,
+                                        266.0,
+                                        33.0,
+                                        22.0
+                                    ],
+                                    "text": "== 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-12",
+                                    "index": 3,
+                                    "maxclass": "outlet",
+                                    "numinlets": 1,
+                                    "numoutlets": 0,
+                                    "patching_rect": [
+                                        249.0,
+                                        351.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-7",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        249.0,
+                                        293.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "+ 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-11",
+                                    "maxclass": "newobj",
+                                    "numinlets": 1,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        ""
+                                    ],
+                                    "patching_rect": [
+                                        99.0,
+                                        306.0,
+                                        116.0,
+                                        22.0
+                                    ],
+                                    "text": "expr 100 + 2000*$i1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-10",
+                                    "index": 2,
+                                    "maxclass": "outlet",
+                                    "numinlets": 1,
+                                    "numoutlets": 0,
+                                    "patching_rect": [
+                                        99.0,
+                                        351.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-4",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "float"
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        227.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "* 5."
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-50",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 2,
+                                    "outlettype": [
+                                        "bang",
+                                        ""
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        298.0,
+                                        34.0,
+                                        22.0
+                                    ],
+                                    "text": "sel 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-45",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "bang"
+                                    ],
+                                    "patching_rect": [
+                                        110.0,
+                                        164.0,
+                                        122.0,
+                                        22.0
+                                    ],
+                                    "text": "metro 1278 @defer 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-43",
+                                    "maxclass": "newobj",
+                                    "numinlets": 1,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        110.0,
+                                        132.0,
+                                        22.0,
+                                        22.0
+                                    ],
+                                    "text": "t 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-42",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        264.0,
+                                        33.0,
+                                        22.0
+                                    ],
+                                    "text": "<= 1"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-41",
+                                    "maxclass": "newobj",
+                                    "numinlets": 3,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "float"
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        196.0,
+                                        171.0,
+                                        22.0
+                                    ],
+                                    "text": "peek~ voice_parameter_buffer"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-40",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        164.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "i"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-33",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        61.0,
+                                        132.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "+ 7"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-26",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 2,
+                                    "outlettype": [
+                                        "",
+                                        ""
+                                    ],
+                                    "patching_rect": [
+                                        61.0,
+                                        100.0,
+                                        103.0,
+                                        22.0
+                                    ],
+                                    "text": "route voice_offset"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-52",
+                                    "index": 1,
+                                    "maxclass": "inlet",
+                                    "numinlets": 0,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        ""
+                                    ],
+                                    "patching_rect": [
+                                        61.0,
+                                        40.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-53",
+                                    "index": 1,
+                                    "maxclass": "outlet",
+                                    "numinlets": 1,
+                                    "numoutlets": 0,
+                                    "patching_rect": [
+                                        50.0,
+                                        342.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            }
+                        ],
+                        "lines": [
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-10",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-11",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-7",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-13",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-33",
+                                        0
+                                    ],
+                                    "order": 1,
+                                    "source": [
+                                        "obj-26",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-43",
+                                        0
+                                    ],
+                                    "order": 0,
+                                    "source": [
+                                        "obj-26",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-40",
+                                        1
+                                    ],
+                                    "source": [
+                                        "obj-33",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-13",
+                                        0
+                                    ],
+                                    "order": 0,
+                                    "source": [
+                                        "obj-4",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-42",
+                                        0
+                                    ],
+                                    "order": 1,
+                                    "source": [
+                                        "obj-4",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-41",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-40",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-4",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-41",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-11",
+                                        0
+                                    ],
+                                    "order": 0,
+                                    "source": [
+                                        "obj-42",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-50",
+                                        0
+                                    ],
+                                    "order": 1,
+                                    "source": [
+                                        "obj-42",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-45",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-43",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-40",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-45",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-53",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-50",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-26",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-52",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-12",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-7",
+                                        0
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "patching_rect": [
+                        537.0,
+                        244.0,
+                        145.0,
+                        22.0
+                    ],
+                    "text": "p unmute_if_follow_mode"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-26",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        390.0,
+                        347.0,
+                        63.0,
+                        22.0
+                    ],
+                    "text": "prepend 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-53",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        588.0,
+                        446.0,
+                        22.0,
+                        22.0
+                    ],
+                    "text": "t 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-52",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        ""
+                    ],
+                    "patching_rect": [
+                        588.0,
+                        414.0,
+                        34.0,
+                        22.0
+                    ],
+                    "text": "sel 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-48",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        467.0,
+                        244.0,
+                        32.0,
+                        22.0
+                    ],
+                    "text": "gate"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-47",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        427.0,
+                        177.0,
+                        22.0,
+                        22.0
+                    ],
+                    "text": "t 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-46",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        503.0,
+                        213.0,
+                        22.0,
+                        22.0
+                    ],
+                    "text": "t 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-90",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        551.0,
+                        414.0,
+                        35.0,
+                        22.0
+                    ],
+                    "saved_object_attributes": {
+                        "attr_comment": ""
+                    },
+                    "text": "out 2"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-44",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patcher": {
+                        "fileversion": 1,
+                        "appversion": {
+                            "major": 9,
+                            "minor": 0,
+                            "revision": 7,
+                            "architecture": "x64",
+                            "modernui": 1
+                        },
+                        "classnamespace": "box",
+                        "rect": [
+                            59.0,
+                            107.0,
+                            640.0,
+                            480.0
+                        ],
+                        "gridsize": [
+                            15.0,
+                            15.0
+                        ],
+                        "boxes": [
+                            {
+                                "box": {
+                                    "id": "obj-34",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "float"
+                                    ],
+                                    "patching_rect": [
+                                        116.0,
+                                        226.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "+ 0."
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-33",
+                                    "maxclass": "newobj",
+                                    "numinlets": 2,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "float"
+                                    ],
+                                    "patching_rect": [
+                                        126.5,
+                                        196.0,
+                                        53.0,
+                                        22.0
+                                    ],
+                                    "text": "* 0.0001"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-32",
+                                    "maxclass": "newobj",
+                                    "numinlets": 5,
+                                    "numoutlets": 4,
+                                    "outlettype": [
+                                        "int",
+                                        "",
+                                        "",
+                                        "int"
+                                    ],
+                                    "patching_rect": [
+                                        126.5,
+                                        164.0,
+                                        65.0,
+                                        22.0
+                                    ],
+                                    "text": "counter 10"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-31",
+                                    "maxclass": "newobj",
+                                    "numinlets": 1,
+                                    "numoutlets": 2,
+                                    "outlettype": [
+                                        "float",
+                                        "bang"
+                                    ],
+                                    "patching_rect": [
+                                        116.0,
+                                        132.0,
+                                        29.5,
+                                        22.0
+                                    ],
+                                    "text": "t f b"
+                                }
+                            },
+                            {
+                                "box": {
+                                    "id": "obj-51",
+                                    "maxclass": "newobj",
+                                    "numinlets": 3,
+                                    "numoutlets": 3,
+                                    "outlettype": [
+                                        "",
+                                        "",
+                                        ""
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        100.0,
+                                        85.0,
+                                        22.0
+                                    ],
+                                    "text": "routepass 0 0."
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-35",
+                                    "index": 1,
+                                    "maxclass": "inlet",
+                                    "numinlets": 0,
+                                    "numoutlets": 1,
+                                    "outlettype": [
+                                        "float"
+                                    ],
+                                    "patching_rect": [
+                                        50.0,
+                                        40.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            },
+                            {
+                                "box": {
+                                    "comment": "",
+                                    "id": "obj-36",
+                                    "index": 1,
+                                    "maxclass": "outlet",
+                                    "numinlets": 1,
+                                    "numoutlets": 0,
+                                    "patching_rect": [
+                                        66.0,
+                                        308.0,
+                                        30.0,
+                                        30.0
+                                    ]
+                                }
+                            }
+                        ],
+                        "lines": [
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-32",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-31",
+                                        1
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-34",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-31",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-33",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-32",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-34",
+                                        1
+                                    ],
+                                    "source": [
+                                        "obj-33",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-36",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-34",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-51",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-35",
+                                        0
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-31",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-51",
+                                        2
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-36",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-51",
+                                        1
+                                    ]
+                                }
+                            },
+                            {
+                                "patchline": {
+                                    "destination": [
+                                        "obj-36",
+                                        0
+                                    ],
+                                    "source": [
+                                        "obj-51",
+                                        0
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "patching_rect": [
+                        402.0,
+                        213.0,
+                        93.0,
+                        22.0
+                    ],
+                    "text": "p smallrandomv"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-32",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        462.0,
+                        143.0,
+                        29.5,
+                        22.0
+                    ],
+                    "text": "+ 0."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-31",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "float",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        462.0,
+                        53.0,
+                        29.5,
+                        22.0
+                    ],
+                    "text": "t f b"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-30",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        472.0,
+                        115.0,
+                        51.0,
+                        22.0
+                    ],
+                    "text": "* -0.001"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-29",
+                    "maxclass": "newobj",
+                    "numinlets": 5,
+                    "numoutlets": 4,
+                    "outlettype": [
+                        "int",
+                        "",
+                        "",
+                        "int"
+                    ],
+                    "patching_rect": [
+                        472.0,
+                        83.0,
+                        65.0,
+                        22.0
+                    ],
+                    "text": "counter 10"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-39",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "int"
+                    ],
+                    "patching_rect": [
+                        626.0,
+                        209.0,
+                        22.0,
+                        22.0
+                    ],
+                    "text": "t 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-36",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        626.0,
+                        177.0,
+                        41.0,
+                        22.0
+                    ],
+                    "text": "del 10"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-35",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        536.0,
+                        209.0,
+                        85.0,
+                        22.0
+                    ],
+                    "text": "prepend panic"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-34",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 3,
+                    "outlettype": [
+                        "int",
+                        "bang",
+                        "int"
+                    ],
+                    "patching_rect": [
+                        536.0,
+                        177.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "t 1 b 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-27",
+                    "maxclass": "newobj",
+                    "numinlets": 0,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        536.0,
+                        144.0,
+                        45.0,
+                        22.0
+                    ],
+                    "text": "r panic"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-21",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        462.0,
+                        177.0,
+                        63.0,
+                        22.0
+                    ],
+                    "text": "prepend tr"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-18",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        462.0,
+                        26.0,
+                        43.0,
+                        22.0
+                    ],
+                    "text": "/ -128."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-13",
+                    "maxclass": "newobj",
+                    "numinlets": 3,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "float",
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        244.0,
+                        70.0,
+                        22.0
+                    ],
+                    "text": "split 0. 999."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-24",
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        606.0,
+                        341.0,
+                        45.0,
+                        22.0
+                    ],
+                    "text": "mute 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-22",
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        651.0,
+                        280.0,
+                        31.0,
+                        22.0
+                    ],
+                    "text": "stop"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-20",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        606.0,
+                        312.0,
+                        41.0,
+                        22.0
+                    ],
+                    "text": "del 50"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-19",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        606.0,
+                        280.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "edge~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-17",
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        267.0,
+                        534.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "2 0 $1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-15",
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        204.0,
+                        499.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "1 0 $1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-12",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        267.0,
+                        467.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "edge~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-10",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        402.0,
+                        244.0,
+                        39.0,
+                        22.0
+                    ],
+                    "text": "/ 128."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-51",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        402.0,
+                        277.0,
+                        62.0,
+                        22.0
+                    ],
+                    "text": "prepend v"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-49",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "float",
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        213.0,
+                        74.0,
+                        22.0
+                    ],
+                    "text": "unpack 0. 0."
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-16",
+                    "maxclass": "newobj",
+                    "numinlets": 3,
+                    "numoutlets": 5,
+                    "outlettype": [
+                        "signal",
+                        "signal",
+                        "signal",
+                        "signal",
+                        "signal"
+                    ],
+                    "patching_rect": [
+                        227.0,
+                        277.0,
+                        107.0,
+                        22.0
+                    ],
+                    "text": "gen~ utility.lfo.ping"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-9",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        183.0,
+                        534.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "out 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-3",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 3,
+                    "outlettype": [
+                        "int",
+                        "int",
+                        "int"
+                    ],
+                    "patching_rect": [
+                        536.0,
+                        377.0,
+                        56.0,
+                        22.0
+                    ],
+                    "text": "thispoly~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-7",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        246.0,
+                        337.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "out~ 2"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-5",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "signal"
+                    ],
+                    "patching_rect": [
+                        240.0,
+                        209.0,
+                        35.0,
+                        22.0
+                    ],
+                    "saved_object_attributes": {
+                        "attr_comment": ""
+                    },
+                    "text": "in~ 2"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-4",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 0,
+                    "patching_rect": [
+                        227.0,
+                        313.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "out~ 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-2",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "signal"
+                    ],
+                    "patching_rect": [
+                        199.0,
+                        209.0,
+                        35.0,
+                        22.0
+                    ],
+                    "saved_object_attributes": {
+                        "attr_comment": ""
+                    },
+                    "text": "in~ 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-1",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        183.0,
+                        8.0,
+                        28.0,
+                        22.0
+                    ],
+                    "text": "in 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-6",
+                    "maxclass": "message",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        ""
+                    ],
+                    "patching_rect": [
+                        537.0,
+                        341.0,
+                        45.0,
+                        22.0
+                    ],
+                    "text": "mute 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-94",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        245.0,
+                        220.0,
+                        22.0
+                    ],
+                    "text": "expr (($f1 == 1) * ($f2 != 0))"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-95",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        ""
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        275.0,
+                        34.0,
+                        22.0
+                    ],
+                    "text": "sel 1"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-96",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        "bang"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        305.0,
+                        42.0,
+                        22.0
+                    ],
+                    "text": "t b b"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-97",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        335.0,
+                        41.0,
+                        22.0
+                    ],
+                    "text": "timer"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-98",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 2,
+                    "outlettype": [
+                        "bang",
+                        ""
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        365.0,
+                        34.0,
+                        22.0
+                    ],
+                    "text": "sel 0"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-99",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "signal"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        395.0,
+                        35.0,
+                        22.0
+                    ],
+                    "text": "sig~"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-100",
+                    "maxclass": "newobj",
+                    "numinlets": 2,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        227.0,
+                        120.0,
+                        22.0
+                    ],
+                    "text": "expr $f1 * ($f2 == 0)"
+                }
+            },
+            {
+                "box": {
+                    "id": "obj-101",
+                    "maxclass": "newobj",
+                    "numinlets": 1,
+                    "numoutlets": 1,
+                    "outlettype": [
+                        "float"
+                    ],
+                    "patching_rect": [
+                        316.0,
+                        235.0,
+                        140.0,
+                        22.0
+                    ],
+                    "text": "expr floor($f1 / 128.)"
+                }
+            }
+        ],
+        "lines": [
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-93",
+                        0
+                    ],
+                    "source": [
+                        "obj-1",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-51",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-10",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-57",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-10",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-11",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-63",
+                        0
+                    ],
+                    "source": [
+                        "obj-12",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-41",
+                        1
+                    ],
+                    "source": [
+                        "obj-13",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-44",
+                        0
+                    ],
+                    "source": [
+                        "obj-13",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-14",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-9",
+                        0
+                    ],
+                    "source": [
+                        "obj-15",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-19",
+                        0
+                    ],
+                    "source": [
+                        "obj-16",
+                        4
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-4",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-16",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-43",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-16",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-58",
+                        0
+                    ],
+                    "source": [
+                        "obj-16",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-62",
+                        1
+                    ],
+                    "source": [
+                        "obj-16",
+                        3
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-7",
+                        0
+                    ],
+                    "source": [
+                        "obj-16",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-9",
+                        0
+                    ],
+                    "source": [
+                        "obj-17",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-31",
+                        0
+                    ],
+                    "source": [
+                        "obj-18",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-20",
+                        0
+                    ],
+                    "source": [
+                        "obj-19",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-22",
+                        0
+                    ],
+                    "source": [
+                        "obj-19",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-2",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-24",
+                        0
+                    ],
+                    "source": [
+                        "obj-20",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-21",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-20",
+                        0
+                    ],
+                    "source": [
+                        "obj-22",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-61",
+                        0
+                    ],
+                    "source": [
+                        "obj-23",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-62",
+                        0
+                    ],
+                    "source": [
+                        "obj-23",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-3",
+                        0
+                    ],
+                    "source": [
+                        "obj-24",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-9",
+                        0
+                    ],
+                    "source": [
+                        "obj-26",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-34",
+                        0
+                    ],
+                    "source": [
+                        "obj-27",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-30",
+                        0
+                    ],
+                    "source": [
+                        "obj-29",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-52",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-3",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-90",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-3",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-32",
+                        1
+                    ],
+                    "source": [
+                        "obj-30",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-29",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-31",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-32",
+                        0
+                    ],
+                    "source": [
+                        "obj-31",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-57",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-31",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-21",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-32",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-46",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-32",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-28",
+                        0
+                    ],
+                    "source": [
+                        "obj-33",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-21",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-34",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-35",
+                        0
+                    ],
+                    "source": [
+                        "obj-34",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-36",
+                        0
+                    ],
+                    "source": [
+                        "obj-34",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-51",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-34",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-35",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-39",
+                        0
+                    ],
+                    "source": [
+                        "obj-36",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-33",
+                        1
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-37",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-33",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-37",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-37",
+                        0
+                    ],
+                    "source": [
+                        "obj-38",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-35",
+                        0
+                    ],
+                    "source": [
+                        "obj-39",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-18",
+                        0
+                    ],
+                    "source": [
+                        "obj-41",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-42",
+                        0
+                    ],
+                    "source": [
+                        "obj-41",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-44",
+                        0
+                    ],
+                    "source": [
+                        "obj-42",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-64",
+                        0
+                    ],
+                    "source": [
+                        "obj-43",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-10",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-44",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-48",
+                        1
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-44",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-93",
+                        3
+                    ],
+                    "source": [
+                        "obj-45",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-48",
+                        0
+                    ],
+                    "source": [
+                        "obj-46",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-21",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-47",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-48",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-47",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-47",
+                        0
+                    ],
+                    "source": [
+                        "obj-48",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        1
+                    ],
+                    "source": [
+                        "obj-5",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-37",
+                        1
+                    ],
+                    "source": [
+                        "obj-50",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-55",
+                        0
+                    ],
+                    "source": [
+                        "obj-50",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-16",
+                        0
+                    ],
+                    "source": [
+                        "obj-51",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-53",
+                        0
+                    ],
+                    "source": [
+                        "obj-52",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-51",
+                        0
+                    ],
+                    "source": [
+                        "obj-53",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-20",
+                        1
+                    ],
+                    "source": [
+                        "obj-54",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-22",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-54",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-41",
+                        0
+                    ],
+                    "source": [
+                        "obj-54",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-57",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-54",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-38",
+                        0
+                    ],
+                    "source": [
+                        "obj-55",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-23",
+                        0
+                    ],
+                    "source": [
+                        "obj-56",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-55",
+                        0
+                    ],
+                    "source": [
+                        "obj-56",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-20",
+                        0
+                    ],
+                    "source": [
+                        "obj-57",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-6",
+                        0
+                    ],
+                    "source": [
+                        "obj-57",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-43",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-58",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-61",
+                        1
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-58",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-15",
+                        0
+                    ],
+                    "source": [
+                        "obj-59",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-3",
+                        0
+                    ],
+                    "source": [
+                        "obj-6",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-59",
+                        1
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-60",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-63",
+                        1
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-60",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-59",
+                        0
+                    ],
+                    "source": [
+                        "obj-61",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-12",
+                        0
+                    ],
+                    "source": [
+                        "obj-62",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-17",
+                        0
+                    ],
+                    "source": [
+                        "obj-63",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-65",
+                        0
+                    ],
+                    "source": [
+                        "obj-64",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-60",
+                        0
+                    ],
+                    "source": [
+                        "obj-65",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-38",
+                        0
+                    ],
+                    "source": [
+                        "obj-67",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-56",
+                        0
+                    ],
+                    "source": [
+                        "obj-8",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-11",
+                        0
+                    ],
+                    "source": [
+                        "obj-93",
+                        4
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-14",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-93",
+                        5
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-26",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-93",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-3",
+                        0
+                    ],
+                    "source": [
+                        "obj-93",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-38",
+                        1
+                    ],
+                    "source": [
+                        "obj-93",
+                        7
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-49",
+                        0
+                    ],
+                    "order": 1,
+                    "source": [
+                        "obj-93",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-50",
+                        0
+                    ],
+                    "source": [
+                        "obj-93",
+                        6
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-54",
+                        0
+                    ],
+                    "order": 0,
+                    "source": [
+                        "obj-93",
+                        5
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-8",
+                        0
+                    ],
+                    "source": [
+                        "obj-93",
+                        9
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "destination": [
+                        "obj-9",
+                        0
+                    ],
+                    "source": [
+                        "obj-93",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-94",
+                        0
+                    ],
+                    "destination": [
+                        "obj-95",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-96",
+                        1
+                    ],
+                    "destination": [
+                        "obj-97",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-96",
+                        0
+                    ],
+                    "destination": [
+                        "obj-97",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-97",
+                        0
+                    ],
+                    "destination": [
+                        "obj-98",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-98",
+                        1
+                    ],
+                    "destination": [
+                        "obj-99",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-99",
+                        0
+                    ],
+                    "destination": [
+                        "obj-16",
+                        2
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-95",
+                        0
+                    ],
+                    "destination": [
+                        "obj-96",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-100",
+                        0
+                    ],
+                    "destination": [
+                        "obj-13",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-49",
+                        0
+                    ],
+                    "destination": [
+                        "obj-101",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-101",
+                        0
+                    ],
+                    "destination": [
+                        "obj-94",
+                        0
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-101",
+                        0
+                    ],
+                    "destination": [
+                        "obj-100",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-49",
+                        1
+                    ],
+                    "destination": [
+                        "obj-94",
+                        1
+                    ]
+                }
+            },
+            {
+                "patchline": {
+                    "source": [
+                        "obj-49",
+                        1
+                    ],
+                    "destination": [
+                        "obj-100",
+                        0
+                    ]
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `utility.lfo.ping` audio block with tap/trigger inputs, configurable modulation assignments, and auxiliary mode selection
- implement a continuous tempo-synchronised LFO in Gen that reuses the ping envelope curve families and exposes target/phase/derivative gate options
- retarget the Max patch and metadata so the new block loads the fresh DSP code and advertises the revised inputs and outputs

## Testing
- not run (Max patches)

------
https://chatgpt.com/codex/tasks/task_e_68cab89dc68c8328b659754e5d883c93